### PR TITLE
Track and annotate largest portfolio gain run

### DIFF
--- a/Scripts and CSV Files/Generate_Graph.py
+++ b/Scripts and CSV Files/Generate_Graph.py
@@ -30,13 +30,66 @@ def download_sp500(start_date: pd.Timestamp, end_date: pd.Timestamp) -> pd.DataF
     return sp500
 
 
-def main() -> None:
+def find_largest_gain(df: pd.DataFrame) -> tuple[pd.Timestamp, pd.Timestamp, float]:
+    """Return the largest rise from a local minimum to the next peak.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        DataFrame containing "Date" and "Total Equity" columns sorted by date.
+
+    Returns
+    -------
+    tuple[pd.Timestamp, pd.Timestamp, float]
+        Start date, end date and percentage gain of the largest run.
+    """
+
+    min_val = float(df["Total Equity"].iloc[0])
+    min_date = pd.Timestamp(df["Date"].iloc[0])
+    peak_val = min_val
+    peak_date = min_date
+    best_gain = 0.0
+    best_start = min_date
+    best_end = peak_date
+
+    for date, val in df[["Date", "Total Equity"]].iloc[1:].itertuples(index=False):
+        val = float(val)
+        date = pd.Timestamp(date)
+        if val > peak_val:
+            peak_val = val
+            peak_date = date
+        elif val < peak_val:
+            gain = (peak_val - min_val) / min_val * 100
+            if gain > best_gain:
+                best_gain = gain
+                best_start = min_date
+                best_end = peak_date
+            min_val = val
+            min_date = date
+            peak_val = val
+            peak_date = date
+
+    gain = (peak_val - min_val) / min_val * 100
+    if gain > best_gain:
+        best_gain = gain
+        best_start = min_date
+        best_end = peak_date
+
+    return best_start, best_end, best_gain
+
+
+def main() -> tuple[pd.Timestamp, pd.Timestamp, float]:
     """Generate and display the comparison graph."""
     chatgpt_totals = load_portfolio_totals()
 
     start_date = pd.Timestamp("2025-06-27")
     end_date = chatgpt_totals["Date"].max()
     sp500 = download_sp500(start_date, end_date)
+
+    largest_start, largest_end, largest_gain = find_largest_gain(chatgpt_totals)
+    largest_peak_value = float(
+        chatgpt_totals.loc[chatgpt_totals["Date"] == largest_end, "Total Equity"].iloc[0]
+    )
 
     plt.figure(figsize=(10, 6))
     plt.style.use("seaborn-v0_8-whitegrid")
@@ -58,6 +111,14 @@ def main() -> None:
         linewidth=2,
     )
 
+    plt.text(
+        largest_end,
+        largest_peak_value + 0.3,
+        f"+{largest_gain:.1f}% largest gain",
+        color="green",
+        fontsize=9,
+    )
+
     final_date = chatgpt_totals["Date"].iloc[-1]
     final_chatgpt = float(chatgpt_totals["Total Equity"].iloc[-1])
     final_spx = sp500["SPX Value ($100 Invested)"].iloc[-1]
@@ -77,7 +138,10 @@ def main() -> None:
     plt.tight_layout()
     plt.show()
 
+    return largest_start, largest_end, largest_gain
+
 
 if __name__ == "__main__":
     print("generating graph...")
-    main()
+    start, end, gain = main()
+    print(f"Largest run from {start.date()} to {end.date()} gained {gain:.2f}%")


### PR DESCRIPTION
## Summary
- compute largest rise from a local minimum to subsequent peak before pullback
- annotate chart with green label for largest run and expose run stats

## Testing
- `python -m py_compile 'Scripts and CSV Files/Generate_Graph.py'`
- `python 'Scripts and CSV Files/Generate_Graph.py'` *(fails: Failed to get ticker '^SPX' reason: Failed to perform, curl: (56) CONNECT tunnel failed, response 403)*


------
https://chatgpt.com/codex/tasks/task_e_68b9c7979cd48330bb9fa48abef19dc3